### PR TITLE
Update redis.php

### DIFF
--- a/redis.php
+++ b/redis.php
@@ -355,8 +355,15 @@ class redis_cli
 
             $block_size = $diff > 8192 ? 8192 : $diff;
 
-            $response .= fread ( $this -> handle, $block_size );
-            $read += $block_size;
+            $chunk = fread ( $this -> handle, $block_size );
+            
+            if($chunk){
+                $chunkLen = strlen($chunk);
+                $read += $chunkLen;
+                $response .= $chunk;
+            } else {
+                fseek( $this -> handle, $read );
+            }
         }
 
         fgets ( $this -> handle );


### PR DESCRIPTION
read_bulk_response should add to the $read variable only the length of what is returned from fread and not what the $block_size is. The way it currently is could lead to an issue where what's returned from fread is shorter than the $block_size leading to the contents of the file being cut short